### PR TITLE
Improve metrics plot clarity with simpler layout

### DIFF
--- a/compare_same_dataset.py
+++ b/compare_same_dataset.py
@@ -202,81 +202,85 @@ def _save_gantt(proc_sched:dict, path:Path, title:str):
 
 def _plot_metrics(results:list[dict], path:Path):
     path.parent.mkdir(parents=True, exist_ok=True)
-    # Order results by ALGO_ORDER
-    ordered=[r for name in ALGO_ORDER for r in results if r['algorithm']==name]
+    ordered = [r for name in ALGO_ORDER for r in results if r['algorithm'] == name]
     if not ordered:
         return
-    names=[r['algorithm'] for r in ordered]
-    makespans=[r['makespan'] for r in ordered]
-    load_bal=[r['load_balance_ratio'] for r in ordered]
-    waits=[r['waiting_time'] for r in ordered]
-    # Determine if energy is present
-    energy_vals=[r['energy_cost'] for r in ordered if r.get('energy_cost') is not None]
-    include_energy = any(ev is not None and ev>0 for ev in energy_vals)
+
+    names = [r['algorithm'] for r in ordered]
+    makespans = [r['makespan'] for r in ordered]
+    load_bal = [r['load_balance_ratio'] for r in ordered]
+    waits = [r['waiting_time'] for r in ordered]
+
+    energy_vals = [r['energy_cost'] for r in ordered if r.get('energy_cost') is not None]
+    include_energy = any(ev is not None and ev > 0 for ev in energy_vals)
     rows = 4 if include_energy else 3
-    fig,ax=plt.subplots(rows,1,figsize=(10, 3*rows), constrained_layout=True)
+
+    width = max(8, 1.2 * len(names))
+    fig, ax = plt.subplots(rows, 1, figsize=(width, 2.8 * rows), layout='constrained')
 
     def _plot_single(a, vals, title, color, ylabel, fmt="{v:.2f}", prefer="min"):
-        bars=a.bar(names, vals, color=color, edgecolor='black', linewidth=0.4, zorder=2)
+        bars = a.bar(names, vals, color=color, edgecolor="black", linewidth=0.4)
         a.set_ylabel(ylabel)
         a.set_title(title)
-        a.tick_params(axis='x', rotation=25)
-        vmin=min(vals); vmax=max(vals); vr=vmax-vmin
-        # Margin so labels placed above bars are always visible
-        if vr == 0:
-            label_gap = (abs(vmax) * 0.1) if vmax != 0 else 1.0
-        else:
-            label_gap = vr * 0.12
-        lower = min(0, vmin - vr*0.05)
-        upper = vmax + label_gap * 2.2
+        a.tick_params(axis='x', rotation=45)
+
+        vmin, vmax = min(vals), max(vals)
+        lower = 0 if vmin >= 0 else vmin * 1.2
+        upper = vmax * 1.25 if vmax > 0 else 1.0
         a.set_ylim(lower, upper)
-        grid_alpha = 0.25
-        a.yaxis.grid(True, linestyle=':', linewidth=0.6, alpha=grid_alpha, zorder=0)
+
+        a.yaxis.grid(True, linestyle=':', linewidth=0.6, alpha=0.25)
+        offset = (upper - lower) * 0.03
 
         def place_text(bar, text):
-            bh = bar.get_height()
-            y = bh + label_gap * 0.6
-            # Ensure stays within axis
-            if y > upper - label_gap * 0.4:
-                # Expand ylim slightly if needed
-                a.set_ylim(lower, y + label_gap)
-                # Recompute upper for subsequent bars
-            a.text(bar.get_x()+bar.get_width()/2, y, text, ha='center', va='bottom', fontsize=8,
-                   bbox=dict(boxstyle='round,pad=0.22', fc='white', ec='none', alpha=0.8))
+            a.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + offset,
+                text,
+                ha='center',
+                va='bottom',
+                fontsize=8,
+            )
 
-        if prefer == 'min':
+        if prefer == "min":
             best_val = vmin
-            for bar,val in zip(bars, vals):
-                pct = (val-best_val)/best_val*100 if best_val!=0 else 0.0
-                label = "(best)" if val==best_val else f"+{pct:.2f}%"
+            for bar, val in zip(bars, vals):
+                pct = (val - best_val) / best_val * 100 if best_val != 0 else 0.0
+                label = "(best)" if val == best_val else f"+{pct:.2f}%"
                 place_text(bar, f"{fmt.format(v=val)}\n{label}")
-        elif prefer == 'max':
+        elif prefer == "max":
             best_val = vmax
-            for bar,val in zip(bars, vals):
-                pct = (best_val - val)/best_val*100 if best_val!=0 else 0.0
-                label = "(best)" if val==best_val else f"+{pct:.2f}% worse"
+            for bar, val in zip(bars, vals):
+                pct = (best_val - val) / best_val * 100 if best_val != 0 else 0.0
+                label = "(best)" if val == best_val else f"+{pct:.2f}% worse"
                 place_text(bar, f"{fmt.format(v=val)}\n{label}")
-        elif prefer == 'close1':
-            deviations=[abs(v-1) for v in vals]
-            best_dev=min(deviations)
-            for bar,val,dev in zip(bars, vals, deviations):
-                pct = dev*100
-                label = "(best)" if dev==best_dev else f"dev {pct:.2f}%"
+        elif prefer == "close1":
+            deviations = [abs(v - 1) for v in vals]
+            best_dev = min(deviations)
+            for bar, val, dev in zip(bars, vals, deviations):
+                pct = dev * 100
+                label = "(best)" if dev == best_dev else f"dev {pct:.2f}%"
                 place_text(bar, f"{fmt.format(v=val)}\n{label}")
         else:
-            for bar,val in zip(bars, vals):
+            for bar, val in zip(bars, vals):
                 place_text(bar, f"{fmt.format(v=val)}")
 
-    _plot_single(ax[0], makespans, 'Makespan', '#4C72B0', 'Makespan', fmt="{v:.3f}", prefer='min')
-    # Load balance ratio: Makespan / Avg Busy (>=1, closer to 1 is better)
-    _plot_single(ax[1], load_bal, 'Load Balance (Makespan / Avg Busy) – closer to 1 is better', '#DD8452', 'LB Ratio', fmt="{v:.3f}", prefer='close1')
-    _plot_single(ax[2], waits, 'Waiting Time', '#55A868', 'Waiting Time', fmt="{v:.3f}")
+    _plot_single(ax[0], makespans, "Makespan", "#4C72B0", "Makespan", fmt="{v:.3f}", prefer="min")
+    _plot_single(
+        ax[1],
+        load_bal,
+        "Load Balance (Makespan / Avg Busy) – closer to 1 is better",
+        "#DD8452",
+        "LB Ratio",
+        fmt="{v:.3f}",
+        prefer="close1",
+    )
+    _plot_single(ax[2], waits, "Waiting Time", "#55A868", "Waiting Time", fmt="{v:.3f}")
     if include_energy:
-        # Replace None with 0 for plotting clarity
-        energy_clean=[(e if e is not None else 0.0) for e in energy_vals]
-        _plot_single(ax[3], energy_clean, 'Energy Cost', '#937860', 'Energy (J)', fmt="{v:.2f}")
-    plt.tight_layout()
-    plt.savefig(path, dpi=150)
+        energy_clean = [(e if e is not None else 0.0) for e in energy_vals]
+        _plot_single(ax[3], energy_clean, "Energy Cost", "#937860", "Energy (J)", fmt="{v:.2f}")
+
+    fig.savefig(path, dpi=150)
     plt.close(fig)
 
 def main():


### PR DESCRIPTION
## Summary
- Refactor `_plot_metrics` to scale figure width with algorithm count and add generous axis margins
- Simplify annotation placement so bar labels remain inside plot bounds without overlap

## Testing
- `python -m py_compile compare_same_dataset.py`
- `python compare_same_dataset.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c0939556808326a4a277c876ea672d